### PR TITLE
replaced hard-coded path with already instantiated var

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,9 +138,9 @@ class netgui(Gtk.Window):
         profileMenu = self.builder.get_object("profilesMenu")
         profiles = os.listdir("/etc/netctl/")
         # Iterate through profiles directory, and add to "Profiles" Menu #
-        for i in profiles:
-            if os.path.isfile("/etc/netctl/" + i):
-               profile = profileMenu.set_submenu(i)   
+        #for i in profiles:
+        #    if os.path.isfile("/etc/netctl/" + i):
+        #       profile = profileMenu.set_submenu(i)   
         # This should automatically detect their wireless device name. I'm not 100% sure
         # if it works on every computer, but we can only know from multiple tests. If
         # it doesn't work, I will re-implement the old way.


### PR DESCRIPTION
In main.py, interactions with interface.cfg were hard-coded to /usr/lib/netgui/interface.cfg.  This threw errors in the AUR version, as interface.cfg lives in /var/lib/netgui/interface.cfg.  This location had already been instantiated as intFile.  Therefore all instances of /usr/lib/netgui/interface.cfg were replaced with intFile.
